### PR TITLE
Deprecate set output

### DIFF
--- a/fetch-vault-token/action.yaml
+++ b/fetch-vault-token/action.yaml
@@ -29,5 +29,4 @@ runs:
         SECRET_ID: ${{ inputs.secret-id }}
       run: |
         VAULT_TOKEN=$(curl -s --request POST '${{ env.VAULT_ADDR }}/v1/auth/approle/login' --header 'Content-Type: application/json' --data-raw '{"role_id": "${{ env.ROLE_ID }}","secret_id": "${{ env.SECRET_ID }}"}' | jq -r '.auth.client_token')
-        echo "::add-mask::$VAULT_TOKEN"
-        echo "::set-output name=vault-token::$VAULT_TOKEN"
+        echo "name=$VAULT_TOKEN" >> $GITHUB_OUTPUT

--- a/fetch-vault-token/action.yaml
+++ b/fetch-vault-token/action.yaml
@@ -29,4 +29,5 @@ runs:
         SECRET_ID: ${{ inputs.secret-id }}
       run: |
         VAULT_TOKEN=$(curl -s --request POST '${{ env.VAULT_ADDR }}/v1/auth/approle/login' --header 'Content-Type: application/json' --data-raw '{"role_id": "${{ env.ROLE_ID }}","secret_id": "${{ env.SECRET_ID }}"}' | jq -r '.auth.client_token')
-        echo "name=$VAULT_TOKEN" >> $GITHUB_OUTPUT
+        echo "::add-mask::$VAULT_TOKEN"
+        echo "vault-token=$VAULT_TOKEN" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# What
- replace `set-output` with env file output method

# Why
- [deprecation of `set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)