### PR TITLE
update setup-node to v3

### DIFF
--- a/get-tenants/action.yaml
+++ b/get-tenants/action.yaml
@@ -18,7 +18,7 @@ runs:
   steps:
     - uses: actions/checkout@v3
     - name: Set up Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 18.11.0
     - name: Get Tenants


### PR DESCRIPTION
to avoid warning in downstream actions